### PR TITLE
Added the missing quoting to the annotations in the volume templates …

### DIFF
--- a/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-data-sts.yaml
@@ -227,7 +227,7 @@ spec:
       name: data
       annotations:
       {{- range $key, $value := .Values.elasticsearch.data.persistence.annotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
       accessModes:

--- a/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
+++ b/helm/opendistro-es/templates/elasticsearch/es-master-sts.yaml
@@ -327,7 +327,7 @@ spec:
       name: data
       annotations:
       {{- range $key, $value := .Values.elasticsearch.master.persistence.annotations }}
-        {{ $key }}: {{ $value }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
     spec:
       accessModes:


### PR DESCRIPTION
The StatefulSet definition can easily become invalid, if you add annotations to the persistent volumes.